### PR TITLE
Align test pipeline ID resolution with production logic

### DIFF
--- a/pipeline/Ingest_test.json
+++ b/pipeline/Ingest_test.json
@@ -460,119 +460,191 @@
 					"scriptBlockExecutionTimeout": "02:00:00"
 				}
 			},
-			{
-				"name": "Atomic Identity Resolution",
-				"type": "Script",
-				"dependsOn": [],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 2,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"linkedServiceName": {
-					"referenceName": "SnowflakeCN",
-					"type": "LinkedServiceReference"
-				},
-				"typeProperties": {
-					"scripts": [
-						{
-							"type": "NonQuery",
-							"text": {
-								"value": "-- Create atomic identity resolution stored procedure (idempotent)\nCREATE OR REPLACE PROCEDURE RESOLVE_TENANT_COMPANY_IDS(\n  TENANT_NAME STRING,\n  COMPANY_NAME STRING\n)\nRETURNS TABLE(RESOLVED_TENANT_ID NUMBER, RESOLVED_COMPANY_ID NUMBER)\nLANGUAGE SQL\nAS\nBEGIN\n  -- Atomic transaction for identity resolution\n  \n  -- Upsert tenant\n  MERGE INTO JAVATEST.TONILO_WAREHOUSE.DIM_TENANT AS tgt\n  USING (SELECT TENANT_NAME AS tenant_name) AS src\n  ON tgt.tenant_name = src.tenant_name\n  WHEN NOT MATCHED THEN\n      INSERT (tenant_name, created_at) VALUES (src.tenant_name, CURRENT_TIMESTAMP());\n\n  -- Get tenant ID\n  LET resolved_tenant_id := (\n    SELECT tenant_id FROM JAVATEST.TONILO_WAREHOUSE.DIM_TENANT \n    WHERE tenant_name = TENANT_NAME\n  );\n\n  -- Upsert company\n  MERGE INTO JAVATEST.TONILO_WAREHOUSE.DIM_COMPANY AS tgt\n  USING (SELECT resolved_tenant_id AS tenant_id, COMPANY_NAME AS company_name) AS src\n  ON tgt.tenant_id = src.tenant_id AND tgt.company_name = src.company_name\n  WHEN NOT MATCHED THEN\n      INSERT (tenant_id, company_name, created_at) \n      VALUES (src.tenant_id, src.company_name, CURRENT_TIMESTAMP());\n\n  -- Return both resolved IDs\n  RETURN TABLE(\n    SELECT \n      resolved_tenant_id as RESOLVED_TENANT_ID,\n      (\n        SELECT company_id \n        FROM JAVATEST.TONILO_WAREHOUSE.DIM_COMPANY\n        WHERE tenant_id = resolved_tenant_id AND company_name = COMPANY_NAME\n      ) as RESOLVED_COMPANY_ID\n  );\nEND;",
-								"type": "Expression"
-							}
-						}
-					],
-					"scriptBlockExecutionTimeout": "02:00:00"
-				}
-			},
-			{
-				"name": "Call Identity Resolution",
-				"type": "Script",
-				"dependsOn": [
-					{
-						"activity": "Atomic Identity Resolution",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 2,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"linkedServiceName": {
-					"referenceName": "SnowflakeCN",
-					"type": "LinkedServiceReference"
-				},
-				"typeProperties": {
-					"scripts": [
-						{
-							"type": "Query",
-							"text": {
-								"value": "CALL RESOLVE_TENANT_COMPANY_IDS('@{pipeline().parameters.tenant_id}', '@{pipeline().parameters.company_id}');",
-								"type": "Expression"
-							}
-						}
-					],
-					"scriptBlockExecutionTimeout": "02:00:00"
-				}
-			},
-			{
-				"name": "Set Resolved Variables",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Call Identity Resolution",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "ResolvedTenantID",
-					"value": {
-						"value": "@string(activity('Call Identity Resolution').output.resultSets[0].rows[0].RESOLVED_TENANT_ID)",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Set Resolved Company ID",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Set Resolved Variables",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "ResolvedCompanyID",
-					"value": {
-						"value": "@string(activity('Call Identity Resolution').output.resultSets[0].rows[0].RESOLVED_COMPANY_ID)",
-						"type": "Expression"
-					}
-				}
-			},
+                        {
+                                "name": "Tenant merge",
+                                "type": "Script",
+                                "dependsOn": [],
+                                "policy": {
+                                        "timeout": "0.12:00:00",
+                                        "retry": 0,
+                                        "retryIntervalInSeconds": 30,
+                                        "secureOutput": false,
+                                        "secureInput": false
+                                },
+                                "userProperties": [],
+                                "linkedServiceName": {
+                                        "referenceName": "SnowflakeCN",
+                                        "type": "LinkedServiceReference"
+                                },
+                                "typeProperties": {
+                                        "scripts": [
+                                                {
+                                                        "type": "NonQuery",
+                                                        "text": {
+                                                                "value": "MERGE INTO JAVATEST.TONILO_WAREHOUSE.DIM_TENANT AS tgt\\nUSING (\\n    SELECT\\n        '@{pipeline().parameters.tenant_id}' AS TENANT_NAME\\n) AS src\\nON tgt.tenant_name = src.tenant_name\\nWHEN MATCHED THEN\\n    UPDATE SET tenant_name = src.tenant_name   -- optional, usually no-op\\nWHEN NOT MATCHED THEN\\n    INSERT (tenant_name, created_at)\\n    VALUES (src.tenant_name, CURRENT_TIMESTAMP);\\n",
+                                                                "type": "Expression"
+                                                        }
+                                                }
+                                        ],
+                                        "scriptBlockExecutionTimeout": "02:00:00"
+                                }
+                        },
+                        {
+                                "name": "LookupTenant",
+                                "type": "Lookup",
+                                "dependsOn": [
+                                        {
+                                                "activity": "Tenant merge",
+                                                "dependencyConditions": [
+                                                        "Completed"
+                                                ]
+                                        }
+                                ],
+                                "policy": {
+                                        "timeout": "0.12:00:00",
+                                        "retry": 0,
+                                        "retryIntervalInSeconds": 30,
+                                        "secureOutput": false,
+                                        "secureInput": false
+                                },
+                                "userProperties": [],
+                                "typeProperties": {
+                                        "source": {
+                                                "type": "SnowflakeV2Source",
+                                                "query": {
+                                                        "value": "SELECT tenant_ID \\nFROM javatest.tonilo_warehouse.dim_tenant \\nWHERE tenant_name = '@{pipeline().parameters.tenant_id}'\\n",
+                                                        "type": "Expression"
+                                                },
+                                                "exportSettings": {
+                                                        "type": "SnowflakeExportCopyCommand"
+                                                }
+                                        },
+                                        "dataset": {
+                                                "referenceName": "SnowflakeLookup",
+                                                "type": "DatasetReference"
+                                        }
+                                }
+                        },
+                        {
+                                "name": "Resolve tenantID",
+                                "type": "SetVariable",
+                                "dependsOn": [
+                                        {
+                                                "activity": "LookupTenant",
+                                                "dependencyConditions": [
+                                                        "Completed"
+                                                ]
+                                        }
+                                ],
+                                "policy": {
+                                        "secureOutput": false,
+                                        "secureInput": false
+                                },
+                                "userProperties": [],
+                                "typeProperties": {
+                                        "variableName": "ResolvedTenantID",
+                                        "value": {
+                                                "value": "@string(activity('LookupTenant').output.firstRow.TENANT_ID)\\n",
+                                                "type": "Expression"
+                                        }
+                                }
+                        },
+                        {
+                                "name": "Company merge",
+                                "type": "Script",
+                                "dependsOn": [
+                                        {
+                                                "activity": "Resolve tenantID",
+                                                "dependencyConditions": [
+                                                        "Completed"
+                                                ]
+                                        }
+                                ],
+                                "policy": {
+                                        "timeout": "0.12:00:00",
+                                        "retry": 0,
+                                        "retryIntervalInSeconds": 30,
+                                        "secureOutput": false,
+                                        "secureInput": false
+                                },
+                                "userProperties": [],
+                                "linkedServiceName": {
+                                        "referenceName": "SnowflakeCN",
+                                        "type": "LinkedServiceReference"
+                                },
+                                "typeProperties": {
+                                        "scripts": [
+                                                {
+                                                        "type": "NonQuery",
+                                                        "text": {
+                                                                "value": "MERGE INTO JAVATEST.TONILO_WAREHOUSE.DIM_COMPANY AS tgt\\nUSING (\\n    SELECT\\n        @{variables('ResolvedTenantID')}      AS TENANT_ID,\\n        '@{pipeline().parameters.company_id}' AS COMPANY_NAME\\n) AS src\\nON  tgt.tenant_id    = src.tenant_id\\nAND tgt.company_name = src.company_name\\n\\nWHEN MATCHED THEN\\n    UPDATE SET company_name = src.company_name   -- optional, usually no-op\\n\\nWHEN NOT MATCHED THEN\\n    INSERT (tenant_id, company_name, created_at)\\n    VALUES (src.tenant_id, src.company_name, CURRENT_TIMESTAMP);\\n",
+                                                                "type": "Expression"
+                                                        }
+                                                }
+                                        ],
+                                        "scriptBlockExecutionTimeout": "02:00:00"
+                                }
+                        },
+                        {
+                                "name": "LookupCompany",
+                                "type": "Lookup",
+                                "dependsOn": [
+                                        {
+                                                "activity": "Company merge",
+                                                "dependencyConditions": [
+                                                        "Completed"
+                                                ]
+                                        }
+                                ],
+                                "policy": {
+                                        "timeout": "0.12:00:00",
+                                        "retry": 0,
+                                        "retryIntervalInSeconds": 30,
+                                        "secureOutput": false,
+                                        "secureInput": false
+                                },
+                                "userProperties": [],
+                                "typeProperties": {
+                                        "source": {
+                                                "type": "SnowflakeV2Source",
+                                                "query": {
+                                                        "value": "SELECT company_ID\\nFROM javatest.tonilo_warehouse.dim_company\\nWHERE tenant_ID = '@{variables('ResolvedTenantID')}'\\n  AND company_name = '@{pipeline().parameters.company_id}'\\n",
+                                                        "type": "Expression"
+                                                },
+                                                "exportSettings": {
+                                                        "type": "SnowflakeExportCopyCommand"
+                                                }
+                                        },
+                                        "dataset": {
+                                                "referenceName": "SnowflakeLookup",
+                                                "type": "DatasetReference"
+                                        }
+                                }
+                        },
+                        {
+                                "name": "Set Resolved Company ID",
+                                "type": "SetVariable",
+                                "dependsOn": [
+                                        {
+                                                "activity": "LookupCompany",
+                                                "dependencyConditions": [
+                                                        "Completed"
+                                                ]
+                                        }
+                                ],
+                                "policy": {
+                                        "secureOutput": false,
+                                        "secureInput": false
+                                },
+                                "userProperties": [],
+                                "typeProperties": {
+                                        "variableName": "ResolvedCompanyID",
+                                        "value": {
+                                                "value": "@string(activity('LookupCompany').output.firstRow.COMPANY_ID)\\n",
+                                                "type": "Expression"
+                                        }
+                                }
+                        },
 			{
 				"name": "Log Pipeline Start",
 				"type": "Script",


### PR DESCRIPTION
## Summary
- match Ingest_test pipeline's tenant/company resolution to production approach using Snowflake merges and lookups

## Testing
- `python -m json.tool pipeline/Ingest_test.json`
- `python -m json.tool pipeline/Snowflake_test.json`


------
https://chatgpt.com/codex/tasks/task_e_68b56897479883269e3bacc3455bab45